### PR TITLE
fix default timezone

### DIFF
--- a/14/alpine/Dockerfile
+++ b/14/alpine/Dockerfile
@@ -27,7 +27,7 @@ RUN bash /tmp/gcloud_install.sh --disable-prompts --install-dir=/usr/local
 ENV PATH $PATH:/usr/local/google-cloud-sdk/bin
 
 # Sets default timezone
-RUN echo "America/Sao_Paulo" > /etc/timezone
+RUN ln -sf /usr/share/zoneinfo/America/Sao_Paulo /etc/localtime
 
 # Cleanup
 RUN rm -rf /tmp/*

--- a/15/alpine/Dockerfile
+++ b/15/alpine/Dockerfile
@@ -28,7 +28,7 @@ RUN bash /tmp/gcloud_install.sh --disable-prompts --install-dir=/usr/local
 ENV PATH $PATH:/usr/local/google-cloud-sdk/bin
 
 # Sets default timezone
-RUN echo "America/Sao_Paulo" > /etc/timezone
+RUN ln -sf /usr/share/zoneinfo/America/Sao_Paulo /etc/localtime
 
 # Cleanup
 RUN rm -rf /tmp/*


### PR DESCRIPTION
the timezone configuration is not working as defined in the dockerfiles.

this commit corrects the definition

Reference:
- https://wiki.alpinelinux.org/wiki/Setting_the_timezone