### PR TITLE
[FEATURE] Adiciona a imagem 14:node-tiny

### DIFF
--- a/14/tiny/Dockerfile
+++ b/14/tiny/Dockerfile
@@ -3,7 +3,7 @@ FROM node:14.15-alpine3.10
 # Forces git clone to ignore unknown host
 ENV GIT_SSH_COMMAND='ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
 
-# Installs dependencies from alpine's repository
+# Installs dependencies from alpine's repository and sets default timezone
 RUN apk --no-cache upgrade && \
     apk --no-cache add make \
                        tzdata \
@@ -19,10 +19,8 @@ RUN apk --no-cache upgrade && \
                        curl \
                        bash \
                        bc \
-                       openssl-dev
-
-# Sets default timezone
-RUN ln -sf /usr/share/zoneinfo/America/Sao_Paulo /etc/localtime
+                       openssl-dev && \
+    ln -sf /usr/share/zoneinfo/America/Sao_Paulo /etc/localtime
 
 # Default command
 CMD ["bash"]

--- a/14/tiny/Dockerfile
+++ b/14/tiny/Dockerfile
@@ -1,0 +1,31 @@
+FROM node:14.15-alpine3.10
+
+# Forces git clone to ignore unknown host
+ENV GIT_SSH_COMMAND='ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
+
+# Installs dependencies from alpine's repository
+RUN apk --no-cache upgrade && \
+    apk --no-cache add make \
+                       tzdata \
+                       ca-certificates \
+                       curl \
+                       gzip \
+                       git \
+                       gcc \
+                       g++ \
+                       openssh \
+                       python \
+                       py-pip \
+                       curl \
+                       bash \
+                       bc \
+                       openssl-dev
+
+# Sets default timezone
+RUN ln -sf /usr/share/zoneinfo/America/Sao_Paulo /etc/localtime
+
+# Cleanup
+RUN rm -rf /tmp/*
+
+# Default command
+CMD ["bash"]

--- a/14/tiny/Dockerfile
+++ b/14/tiny/Dockerfile
@@ -24,8 +24,5 @@ RUN apk --no-cache upgrade && \
 # Sets default timezone
 RUN ln -sf /usr/share/zoneinfo/America/Sao_Paulo /etc/localtime
 
-# Cleanup
-RUN rm -rf /tmp/*
-
 # Default command
 CMD ["bash"]


### PR DESCRIPTION
Esse commit adiciona a imagem 14:node-tiny para ser utilizada nos projetos do frontend-saas onde não é necessário o cliente do Google, pois o cliente é utilizado da imagem arquivei/pipeline.